### PR TITLE
Mount local libmoon in docker

### DIFF
--- a/docker.mk
+++ b/docker.mk
@@ -18,7 +18,7 @@ MAX_CORES ?= 3
 MOONGEN_DIR ?= $(or $(basename $(dirname $(shell pwd)))/MoonGen,\
 ~/williamofockham/MoonGen)
 
-FILES_TO_MOUNT := $(foreach f,$(filter-out build libmoon,\
+FILES_TO_MOUNT := $(foreach f,$(filter-out build,\
 $(notdir $(wildcard $(MOONGEN_DIR)/*))), -v $(MOONGEN_DIR)/$(f):/opt/moongen/$(f))
 BASE_MOUNT := -v $(BASE_DIR):/opt/$(CONTAINER)
 


### PR DESCRIPTION
We weren't mounting this before, so it was being pulled from github when
the box started and built. Kind of a problem when you're doing local
libmoon work.