### PR TITLE
hofs for mutable updates after swap, insert, remove

### DIFF
--- a/framework/src/headers/ip/v6/nf_macros.rs
+++ b/framework/src/headers/ip/v6/nf_macros.rs
@@ -30,8 +30,8 @@ macro_rules! srh_insert {
                         *GenericArray::<_, $utype>::from_slice(&$segments[..]),
                     );
 
-                    if let Ok(()) = $pkt.insert_header(&srh) {
-                        Some(srh.offset() as isize)
+                    if let Ok(insert_diff) = $pkt.insert_header(&srh) {
+                        Some(insert_diff as isize)
                     } else {
                         None
                     }


### PR DESCRIPTION
- [x] First Merge https://github.com/williamofockham/NetBricks/pull/38 and I'll rebase
- [x] Needs https://github.com/williamofockham/NetBricks/pull/42 merged too. 

Notes: 

* adds insert_header_fn, swap_header_fn, remove_header_fn
* good for updating headers after packet changes
* made the ol' insert_header return a diff, like the others
* update test, brings in a bit of
  https://github.com/williamofockham/NetBricks/pull/38
  * the above pr will have been merged first
* prevents rustfmt from touch those lined-up comments if we want em to