### PR TITLE
Impl FromStr for MacAddress

### DIFF
--- a/framework/Cargo.toml
+++ b/framework/Cargo.toml
@@ -27,7 +27,7 @@ serde = "1.0"
 serde_derive = "1.0"
 # Hack for SHM
 uuid = { version = "*", features=["v4"] }
-error-chain = "*"
+error-chain = "0.12.0"
 num = "0.1"
 num-derive="0.2"
 num-traits = "0.2"

--- a/framework/Cargo.toml
+++ b/framework/Cargo.toml
@@ -34,6 +34,7 @@ num-traits = "0.2"
 generic-array = ">=0.11.0"
 crossbeam = "=0.4"
 rayon = "1.0.2"
+hex = "0.3.2"
 
 [features]
 default = []

--- a/framework/src/common/errors.rs
+++ b/framework/src/common/errors.rs
@@ -85,6 +85,11 @@ error_chain! {
             description("Failed to remove header from packet")
                 display("Failed to remove header from packet")
         }
+
+        FailedToParseMacAddress(s: String) {
+            description("Failed to parse MAC address")
+                display("Failed to parse MAC address: '{}'", s)
+        }
     }
 
     foreign_links {

--- a/framework/src/headers/mac.rs
+++ b/framework/src/headers/mac.rs
@@ -5,6 +5,9 @@ use std::default::Default;
 use std::fmt;
 use std::hash::Hash;
 use std::hash::Hasher;
+use std::str::FromStr;
+
+extern crate hex;
 
 const IPV4_ETHER_TYPE: u16 = 0x0800;
 const IPV6_ETHER_TYPE: u16 = 0x86DD;
@@ -24,7 +27,7 @@ pub enum EtherType {
     VlanTFDbl = VLAN_TAG_FRAME_DBL,
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 #[repr(C, packed)]
 pub struct MacAddress {
     pub addr: [u8; 6],
@@ -56,6 +59,19 @@ impl MacAddress {
     #[inline]
     pub fn copy_address(&mut self, other: &MacAddress) {
         self.addr.copy_from_slice(&other.addr);
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub struct MacParseError(());
+
+impl FromStr for MacAddress {
+    type Err = MacParseError;
+    fn from_str(s: &str) -> Result<MacAddress, MacParseError> {
+        match hex::decode(s.replace(":", "").replace("-", "")) {
+            Ok(ref v) if v.len() == 6 => Ok(MacAddress::new_from_slice(v.as_slice())),
+            _ => Err(MacParseError(())),
+        }
     }
 }
 
@@ -151,5 +167,47 @@ impl MacHeader {
         src.copy_address(&self.src);
         self.src.copy_address(&self.dst);
         self.dst.copy_address(&src);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_str() {
+        let address = "ba:dc:af:eb:ee:f4";
+        let parsed = MacAddress::from_str(address).map(|a| a.to_string());
+        assert_eq!(parsed, Ok(address.to_string()));
+    }
+
+    #[test]
+    fn test_from_str_dashes() {
+        let address = "ba-dc-af-eb-ee-f2";
+        let expected = "ba:dc:af:eb:ee:f2".to_string();
+        let parsed = MacAddress::from_str(address).map(|a| a.to_string());
+        assert_eq!(parsed, Ok(expected));
+    }
+
+    #[test]
+    fn test_from_str_no_delimiters() {
+        let address = "badcafebeef3";
+        let expected = "ba:dc:af:eb:ee:f3".to_string();
+        let parsed = MacAddress::from_str(address).map(|a| a.to_string());
+        assert_eq!(parsed, Ok(expected));
+    }
+
+    #[test]
+    fn test_unparseable_address() {
+        let address = "go:od:ca:fe:be:ef";
+        let parsed = MacAddress::from_str(address);
+        assert_eq!(parsed, Err(MacParseError(())));
+    }
+
+    #[test]
+    fn test_unparseable_address2() {
+        let address = "ab:ad:ad:d4";
+        let parsed = MacAddress::from_str(address);
+        assert_eq!(parsed, Err(MacParseError(())));
     }
 }

--- a/framework/src/lib.rs
+++ b/framework/src/lib.rs
@@ -34,6 +34,7 @@ extern crate lazy_static;
 extern crate libc;
 extern crate net2;
 extern crate num;
+extern crate hex;
 
 #[macro_use]
 extern crate num_derive;


### PR DESCRIPTION
Make it easier to read values from config file, in particular. Pretty
lenient: as long as it looks like a MacAddr after you strip out the
colons and/or dashes, it'll parse.