### PR TITLE
Impl PartialEq for RawPacket

### DIFF
--- a/framework/src/packets/ethernet.rs
+++ b/framework/src/packets/ethernet.rs
@@ -99,6 +99,7 @@ pub struct EthernetHeader {
 impl Header for EthernetHeader {}
 
 /// Ethernet packet
+#[derive(Debug)]
 pub struct Ethernet {
     envelope: RawPacket,
     mbuf: *mut MBuf,

--- a/framework/src/packets/icmp/v6/mod.rs
+++ b/framework/src/packets/icmp/v6/mod.rs
@@ -169,6 +169,7 @@ pub trait Icmpv6Packet<E: Ipv6Packet, P: Icmpv6Payload>:
 }
 
 /// ICMPv6 packet
+#[derive(Debug)]
 pub struct Icmpv6<E: Ipv6Packet, P: Icmpv6Payload> {
     envelope: E,
     mbuf: *mut MBuf,

--- a/framework/src/packets/ip/v4.rs
+++ b/framework/src/packets/ip/v4.rs
@@ -165,6 +165,7 @@ impl Default for Ipv4Header {
 impl Header for Ipv4Header {}
 
 /// IPv4 packet
+#[derive(Debug)]
 pub struct Ipv4 {
     envelope: Ethernet,
     mbuf: *mut MBuf,

--- a/framework/src/packets/ip/v6/mod.rs
+++ b/framework/src/packets/ip/v6/mod.rs
@@ -131,6 +131,7 @@ impl Default for Ipv6Header {
 impl Header for Ipv6Header {}
 
 /// IPv6 packet
+#[derive(Debug)]
 pub struct Ipv6 {
     envelope: Ethernet,
     mbuf: *mut MBuf,

--- a/framework/src/packets/ip/v6/srh.rs
+++ b/framework/src/packets/ip/v6/srh.rs
@@ -127,6 +127,7 @@ pub type Segment = Ipv6Addr;
 #[fail(display = "Segment list length must be greater than 0")]
 pub struct BadSegmentsError;
 
+#[derive(Debug)]
 pub struct SegmentRouting<E: Ipv6Packet> {
     envelope: E,
     mbuf: *mut MBuf,

--- a/framework/src/packets/raw.rs
+++ b/framework/src/packets/raw.rs
@@ -1,4 +1,3 @@
-use std::cmp;
 use common::Result;
 use native::zcsi::{mbuf_alloc, MBuf};
 use packets::{buffer, Header, Packet};
@@ -15,28 +14,19 @@ pub struct RawPacket {
     mbuf: *mut MBuf,
 }
 
-/// Compare RawPackets. This probably isn't something you want to be doing a lot of at runtime.
+// Compare RawPackets. This probably isn't something you want to be doing a lot of at runtime.
 impl PartialEq for RawPacket {
     fn eq(&self, other: &RawPacket) -> bool {
         unsafe {
             if (*self.mbuf).data_len() != (*other.mbuf).data_len() {
-                return false;
-            }
-            let mut offset = 0;
-            let mut remaining = (*self.mbuf).data_len();
-            while remaining > 0 {
-                let to_read = cmp::min(remaining, 32);
-                let lhs_slice = &(*read_slice::<u8>(self.mbuf, offset, to_read).unwrap());
-                let rhs_slice = &(*read_slice::<u8>(other.mbuf, offset, to_read).unwrap());
-
-                if lhs_slice != rhs_slice {
-                    return false;
-                }
-                remaining = remaining - to_read;
-                offset = offset + to_read;
+                false
+            } else {
+                let len = (*self.mbuf).data_len();
+                let lhs_slice = &(*read_slice::<u8>(self.mbuf, 0, len).unwrap());
+                let rhs_slice = &(*read_slice::<u8>(other.mbuf, 0, len).unwrap());
+                lhs_slice == rhs_slice
             }
         }
-        true
     }
 }
 

--- a/framework/src/packets/tcp.rs
+++ b/framework/src/packets/tcp.rs
@@ -154,6 +154,7 @@ const SYN: u8 = 0b0000_0010;
 const FIN: u8 = 0b0000_0001;
 
 /// TCP packet
+#[derive(Debug)]
 pub struct Tcp<E: IpPacket> {
     envelope: E,
     mbuf: *mut MBuf,

--- a/framework/src/packets/udp.rs
+++ b/framework/src/packets/udp.rs
@@ -70,6 +70,7 @@ pub struct UdpHeader {
 impl Header for UdpHeader {}
 
 /// UDP packet
+#[derive(Debug)]
 pub struct Udp<E: IpPacket> {
     envelope: E,
     mbuf: *mut MBuf,


### PR DESCRIPTION
This should mostly be used for testing, it doesn't have much purpose in
real-time packet processing. Didn't gate it with a #[cfg(test)], though,
as dependent projects that need to test for packet equivalence need
access to it.

Also derived the Debug trait on all the packet types for testing
goodness.