### PR TITLE
Add emit() operator

### DIFF
--- a/framework/src/operators/emit_batch.rs
+++ b/framework/src/operators/emit_batch.rs
@@ -1,0 +1,34 @@
+use super::{Batch, PacketError};
+use packets::Packet;
+
+/// Lazily-evaluated emit operator
+///
+/// Interrupts processing with a short-circuit error that simply emits the packet
+pub struct EmitBatch<B: Batch> {
+    source: B
+}
+
+impl<B: Batch> EmitBatch<B> {
+    #[inline]
+    pub fn new(source: B) -> Self {
+        EmitBatch { source }
+    }
+}
+
+impl<B: Batch> Batch for EmitBatch<B> {
+    type Item = B::Item;
+
+    #[inline]
+    fn next(&mut self) -> Option<Result<Self::Item, PacketError>> {
+        self.source.next().map(|item| match item {
+            Ok(packet) => Err(PacketError::Emit(packet.mbuf())),
+            e @ Err(_) => e,
+        })
+    }
+
+
+    #[inline]
+    fn receive(&mut self) {
+        self.source.receive();
+    }
+}

--- a/framework/src/operators/send_batch.rs
+++ b/framework/src/operators/send_batch.rs
@@ -38,6 +38,9 @@ impl<B: Batch, Tx: PacketTx> Executable for SendBatch<B, Tx> {
                 Ok(packet) => {
                     transmit_q.push(packet.mbuf());
                 }
+                Err(PacketError::Emit(mbuf)) => {
+                    transmit_q.push(mbuf);
+                }
                 Err(PacketError::Drop(mbuf)) => {
                     drop_q.push(mbuf);
                 }


### PR DESCRIPTION
For short-circuiting processing and emitting packet as-is. Useful for
carving off subset of incoming packet types, handling them, and moving
on without having to build a whole tree of functions that call one
another on the not-match branch of the group_by operator.