### PR TITLE
Implement copy/clone for Ipv6

### DIFF
--- a/framework/src/packets/ip/v6/mod.rs
+++ b/framework/src/packets/ip/v6/mod.rs
@@ -132,7 +132,7 @@ impl Default for Ipv6Header {
 impl Header for Ipv6Header {}
 
 /// IPv6 packet
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 pub struct Ipv6 {
     envelope: Ethernet,
     mbuf: *mut MBuf,


### PR DESCRIPTION
We need to implement copy/clone for ipv6 since ownership is transferred calling parse_icmp6
```
  --> src/nf/icmpv6.rs:37:13
   |
15 |     if let Ok(Icmpv6Message::RouterAdvertisement(advert)) = ipv6.parse_icmpv6() {
   |                                                             ---- value moved here
...
37 |     Ok(Some(ipv6))
   |             ^^^^ value used here after move
```